### PR TITLE
fix bug when header key is null

### DIFF
--- a/src/main/java/com/codemagi/burp/parser/HttpRequest.java
+++ b/src/main/java/com/codemagi/burp/parser/HttpRequest.java
@@ -378,6 +378,12 @@ public class HttpRequest {
 
             //split the headers into name-value pairs
             String[] split = currLine.split(": ");
+            
+            if (split.length < 2) {
+                split = new String[] {
+                    split[0], ""
+                };
+            }
 
             String headerName = Utils.trim(split[0]);
             String headerValue = Utils.trim(split[1]);

--- a/src/main/java/com/codemagi/burp/parser/HttpResponse.java
+++ b/src/main/java/com/codemagi/burp/parser/HttpResponse.java
@@ -225,6 +225,12 @@ public class HttpResponse {
             //split the headers into name-value pairs
             String[] split = currLine.split(": ");
 
+            if (split.length < 2) {
+                split = new String[] {
+                    split[0], ""
+                };
+            }
+            
             String headerName = Utils.trim(split[0]);
             String headerValue = Utils.trim(split[1]);
 


### PR DESCRIPTION
think about header:
```
abc:\s\n
```
it will crash.

this change fix this bug.