### PR TITLE
Enabled status should not influence selected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.codemagi</groupId>
     <artifactId>burp-suite-utils</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <name>Burp Suite Utils</name>
     <description>The Burp Suite Utils project provides developers with APIs for building Burp Suite Extensions.</description>

--- a/src/main/java/com/monikamorrow/burp/ToolsScopeComponent.java
+++ b/src/main/java/com/monikamorrow/burp/ToolsScopeComponent.java
@@ -133,25 +133,25 @@ public class ToolsScopeComponent extends javax.swing.JPanel {
         boolean selected = false;
         switch (tool) {
             case IBurpExtenderCallbacks.TOOL_PROXY:
-                selected = jCheckBoxProxy.isSelected() && jCheckBoxProxy.isEnabled();
+                selected = jCheckBoxProxy.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_REPEATER:
-                selected = jCheckBoxRepeater.isSelected() && jCheckBoxRepeater.isEnabled();
+                selected = jCheckBoxRepeater.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_SCANNER:
-                selected = jCheckBoxScanner.isSelected() && jCheckBoxScanner.isEnabled();
+                selected = jCheckBoxScanner.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_INTRUDER:
-                selected = jCheckBoxIntruder.isSelected() && jCheckBoxIntruder.isEnabled();
+                selected = jCheckBoxIntruder.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_SEQUENCER:
-                selected = jCheckBoxSequencer.isSelected() && jCheckBoxSequencer.isEnabled();
+                selected = jCheckBoxSequencer.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_SPIDER:
-                selected = jCheckBoxSpider.isSelected() && jCheckBoxSpider.isEnabled();
+                selected = jCheckBoxSpider.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_EXTENDER:
-                selected = jCheckBoxExtender.isSelected() && jCheckBoxExtender.isEnabled();
+                selected = jCheckBoxExtender.isSelected();
                 break;
             case IBurpExtenderCallbacks.TOOL_TARGET:
                 break;


### PR DESCRIPTION
Changed isToolSelected() method to return only the selected value of a tool checkbox, regardless of whether the checkbox is enabled in the GUI. Fixes a bug that caused some requests to be inadvertently skipped in the passive scanner.